### PR TITLE
Add an `Integer` primitive.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -389,7 +389,9 @@ let genericIndexable = lazy(() => seqMap(generic,
       return generic;
     }));
 
-let type = alt(range,
+let type = alt(
+  Parsimmon.string('Integer').map(() => ({ kind: 'Integer' })),
+  range,
   genericIndexable,
   generic,
   id.map((id) => {

--- a/lib/types/factory.js
+++ b/lib/types/factory.js
@@ -15,6 +15,7 @@ module.exports = factory;
 let errors = require('../errors.js');
 let ArrayType = require('./array.js');
 let Either = require('./either.js');
+let Integer = require('./integer');
 let Output = require('./output.js');
 let Range = require('./range.js');
 let RecordType = require('./record.js');
@@ -27,6 +28,8 @@ let make = function(decl, env, name) {
     return new RecordType(decl, env, name);
   } else if (decl.kind == 'either') {
     return new Either.Type(decl, env, name);
+  } else if (decl.kind == 'Integer') {
+    return new Integer.Type(decl, env, name);
   } else if (decl.kind == 'alias') {
     let t = env.getType(decl.value);
     if (t === undefined) {

--- a/lib/types/integer.js
+++ b/lib/types/integer.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const errors = require('../errors.js');
+const Type = require('./type.js');
+const Value = require('./value.js');
+
+class IntegerValue extends Value {
+  constructor(type) {
+    super(type);
+    this.value = 0;
+  }
+
+  assign(newValue) {
+    if (typeof newValue == 'number') {
+      this.value = newValue;
+    } else if (newValue.value !== undefined && typeof newValue.value == 'number') {
+      this.value = newValue.value;
+    } else {
+      throw new errors.Internal(`Trying to assign ${newValue.type} to Integer;`);
+    }
+  }
+
+  equals(other) {
+    return this.type == other.type && this.value == other.value;
+  }
+
+  innerToString() {
+    return `${this.value}`;
+  }
+
+  assignJSON(spec) {
+    this.value = spec;
+  }
+
+  toJSON() {
+    return this.value;
+  }
+
+  toString() {
+    return `${this.value}`;
+  }
+}
+
+class IntegerType extends Type {
+  constructor() {
+    super(null, null, 'Integer');
+  }
+  equals(other) {
+    return other === IntegerType.singleton;
+  }
+  makeDefaultValue() {
+    return new IntegerValue(this);
+  }
+  toString() {
+    return 'Integer';
+  }
+}
+
+IntegerType.singleton = new IntegerType();
+
+module.exports = {
+  Type: IntegerType,
+  Value: IntegerValue,
+};

--- a/lib/types/types.js
+++ b/lib/types/types.js
@@ -12,6 +12,7 @@ let ArrayType = require('./array.js');
 let Either = require('./either.js');
 let BlackHoleNumberType = require('./blackholenumber.js').Type;
 let NumberType = require('./number.js').Type;
+let IntegerType = require('./integer.js').Type;
 let RangeType = require('./range.js').Type;
 let VarLen = require('./varlen.js');
 
@@ -50,7 +51,8 @@ let haveEquality = function(left, right) {
 let isNumeric = function(t) {
   return (t instanceof NumberType ||
     t instanceof RangeType ||
-    t instanceof BlackHoleNumberType);
+    t instanceof BlackHoleNumberType ||
+    t instanceof IntegerType);
 };
 
 let haveOrdering = function(left, right) {


### PR DESCRIPTION
It's sometimes convenient to specify something as an integer, rather
than supplying a possible range. This implementation is probably not
robust enough and should be backed by bignum, but I'm treating it as an
experiment.

Generalizing, it would be nice to add a primitive `String` type.

I understand the appeal in having a minimal language with a small
surface area, however builtins are rather convenient.

Test plan:
* `npm test`
* Run this contract:
  https://gist.github.com/joelburget/7b9693bb4abde38a046ad2ab3e758e62