### PR TITLE
Add `else if` to language

### DIFF
--- a/doc/LANGUAGE-GUIDE.md
+++ b/doc/LANGUAGE-GUIDE.md
@@ -263,17 +263,21 @@ result in a compiler error.
 
 ### If Statements
 
-The standard stuff. No parentheses are normally required around the expression
-(if you have an empty code block and a single identifier for your condition,
-you may need parentheses to disambiguate parsing; it's rare but came up in the
+The standard stuff; `if`, `else`, and `else if` statements should work like you
+expect. No parentheses are normally required around the expression (if you have
+an empty code block and a single identifier for your condition, you may need
+parentheses to disambiguate parsing; it's rare but came up in the
 toomanybananas example).
 Braces are required around the code blocks.
 
-     > if bananas == 0 {
-     .   state = GoingToStore;
-     . } else {
+     > if bananas > 0 {
      .   bananas -= 1;
      .   state = Happy;
+     . } else if (notePresent) {
+     .   // Roommate at store: try again later
+     . } else {
+     .   notePresent = True;
+     .   state = GoingToStore;
      . }
      > if bananas == 3 {
      .   bananas = 4;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -613,7 +613,15 @@ let whileLoop = seqMap(keywords.while,
 let ifElse = seqMap(keywords.if,
   expr,
   block,
-  (keywords.else).then(block).times(0, 1).map((elses) => {
+  (keywords.else).then(alt(block, lazy(() => {
+    return ifElse;
+  }).source().map((elseIf) =>({
+    kind: 'block',
+    code: {
+      kind: 'sequence',
+      statements: [elseIf],
+    },
+  })))).times(0, 1).map((elses) => {
     if (elses.length == 0) {
       return {
         kind: 'sequence',

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -610,33 +610,34 @@ let whileLoop = seqMap(keywords.while,
     code: block,
   }));
 
-let ifElse = seqMap(keywords.if,
-  expr,
-  block,
-  (keywords.else).then(alt(block, lazy(() => {
-    return ifElse;
-  }).source().map((elseIf) =>({
-    kind: 'block',
-    code: {
-      kind: 'sequence',
-      statements: [elseIf],
-    },
-  })))).times(0, 1).map((elses) => {
-    if (elses.length == 0) {
-      return {
+let ifElse = lazy(() => {
+  return seqMap(keywords.if,
+    expr,
+    block,
+    (keywords.else).then(alt(block, ifElse.source().map((elseIf) =>({
+      kind: 'block',
+      code: {
         kind: 'sequence',
-        statements: [],
-      };
-    } else {
-      return elses[0];
-    }
-  }),
-  (_, condition, thenblock, elseblock) => ({
-    kind: 'ifelse',
-    condition: condition,
-    thenblock: thenblock,
-    elseblock: elseblock,
-  }));
+        statements: [elseIf],
+      },
+    })))).times(0, 1).map((elses) => {
+      if (elses.length == 0) {
+        return {
+          kind: 'sequence',
+          statements: [],
+        };
+      } else {
+        return elses[0];
+      }
+    }),
+    (_, condition, thenblock, elseblock) => ({
+      kind: 'ifelse',
+      condition: condition,
+      thenblock: thenblock,
+      elseblock: elseblock,
+    })
+  )
+});
 
 let invariant = seqMap(keywords.invariant,
   id,

--- a/test/statements/ifelse.js
+++ b/test/statements/ifelse.js
@@ -69,5 +69,47 @@ describe('statements/ifelse.js', function() {
       `);
       assert.equal(module.env.getVar('x').toString(), '1');
     });
+
+    it('else-if True', function() {
+      let module = testing.run(`
+        var x : 0..3;
+        if False {
+          x = 1;
+        } else if True {
+          x = 2;
+        } else {
+          x = 3;
+        }
+      `);
+      assert.equal(module.env.getVar('x').toString(), '2');
+    });
+
+    it('else-if False', function() {
+      let module = testing.run(`
+        var x : 0..3;
+        if False {
+          x = 1;
+        } else if False {
+          x = 2;
+        } else {
+          x = 3;
+        }
+      `);
+      assert.equal(module.env.getVar('x').toString(), '3');
+    });
+
+    it('else-if expression', function() {
+      let module = testing.run(`
+        var x : 0..3;
+        if False {
+          x = 1;
+        } else if True == True {
+          x = 2;
+        } else {
+          x = 3;
+        }
+      `);
+      assert.equal(module.env.getVar('x').toString(), '2');
+    });
   });
 });


### PR DESCRIPTION
The language now provides `else if` as syntactic sugar for an `if`
statement nested within an `else` block.

Close #14
